### PR TITLE
Fixing the MidiChannel Type Problem

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -8,7 +8,7 @@ const noteLengths = getNoteLengths({ bpm: 137 });
 
 const tr8 = new Tr8({
   port: 'MX-1 USB1',
-  channel: 10,
+  channel: 9,
   configuration: {
     drumSet: 'tr909',
     snareDrum: {
@@ -19,7 +19,7 @@ const tr8 = new Tr8({
 
 const tb3 = new Tb3({
   port: 'MX-1 USB2',
-  channel: 2,
+  channel: 1,
   configuration: {
     sound: 1,
     cutoff: 64,
@@ -29,7 +29,7 @@ const tb3 = new Tb3({
 
 const system8 = new System8({
   port: 'MX-1 USB4',
-  channel: 1,
+  channel: 0,
   configuration: {
     sound: 4
   }

--- a/lib/Instrument.ts
+++ b/lib/Instrument.ts
@@ -1,30 +1,27 @@
 import { getNoteValue } from './utils/getNoteValue';
-import { MidiChannel } from './types/MidiChannel';
 import { Note } from './types/Note';
 import { Octave } from './types/Octave';
-import { Output } from 'easymidi';
+import { Channel, Output } from 'easymidi';
 
 abstract class Instrument {
   protected readonly port: Output;
 
-  protected readonly channel: number;
+  protected readonly channel: Channel;
 
   public constructor ({ port, channel }: {
     port: string;
-    channel: MidiChannel;
+    channel: Channel;
   }) {
     this.port = new Output(port, false);
-    this.channel = channel - 1;
+    this.channel = channel;
   }
 
   protected setContinuousController ({ controller, value }: {
     controller: number;
     value: number;
   }): void {
-    // TODO: Figure out why the following line does not work without the cast
-    //       to any, and fix it.
     this.port.send('cc', {
-      channel: this.channel as any,
+      channel: this.channel,
       controller,
       value
     });
@@ -34,9 +31,7 @@ abstract class Instrument {
     value: number;
   }): void {
     this.port.send('program', {
-      // TODO: Figure out why the following line does not work without the cast
-      //       to any, and fix it.
-      channel: this.channel as any,
+      channel: this.channel,
       number: value
     });
   }
@@ -48,18 +43,14 @@ abstract class Instrument {
     length: number;
   }): void {
     this.port.send('noteon', {
-      // TODO: Figure out why the following line does not work without the cast
-      //       to any, and fix it.
-      channel: this.channel as any,
+      channel: this.channel,
       note: getNoteValue({ name, octave }),
       velocity
     });
 
     setTimeout((): void => {
       this.port.send('noteoff', {
-        // TODO: Figure out why the following line does not work without the cast
-        //       to any, and fix it.
-        channel: this.channel as any,
+        channel: this.channel,
         note: getNoteValue({ name, octave }),
         velocity
       });
@@ -69,9 +60,7 @@ abstract class Instrument {
   public stop (): void {
     for (let noteValue = 0; noteValue <= 127; noteValue++) {
       this.port.send('noteoff', {
-        // TODO: Figure out why the following line does not work without the cast
-        //       to any, and fix it.
-        channel: this.channel as any,
+        channel: this.channel,
         note: noteValue,
         velocity: 127
       });

--- a/lib/System8/System8.ts
+++ b/lib/System8/System8.ts
@@ -1,13 +1,13 @@
 import { Configuration } from './Configuration';
+import { Channel } from 'easymidi';
 import { Instrument } from '../Instrument';
-import { MidiChannel } from '../types/MidiChannel';
 import { Note } from '../types/Note';
 import { Octave } from '../types/Octave';
 
 class System8 extends Instrument {
   public constructor ({ port, channel, configuration }: {
     port: string;
-    channel: MidiChannel;
+    channel: Channel;
     configuration?: Configuration;
   }) {
     super({ port, channel });

--- a/lib/Tb3/Tb3.ts
+++ b/lib/Tb3/Tb3.ts
@@ -1,13 +1,13 @@
 import { Configuration } from './Configuration';
+import { Channel } from 'easymidi';
 import { Instrument } from '../Instrument';
-import { MidiChannel } from '../types/MidiChannel';
 import { Note } from '../types/Note';
 import { Octave } from '../types/Octave';
 
 class Tb3 extends Instrument {
   public constructor ({ port, channel, configuration }: {
     port: string;
-    channel: MidiChannel;
+    channel: Channel;
     configuration?: Configuration;
   }) {
     super({ port, channel });

--- a/lib/Tr8/Tr8.ts
+++ b/lib/Tr8/Tr8.ts
@@ -1,7 +1,7 @@
 import { Configuration } from './Configuration';
+import { Channel } from 'easymidi';
 import { flaschenpost } from 'flaschenpost';
 import { Instrument } from '../Instrument';
-import { MidiChannel } from '../types/MidiChannel';
 import { Note } from '../types/Note';
 import * as errors from '../errors';
 
@@ -15,7 +15,7 @@ const drumSets = {
 class Tr8 extends Instrument {
   public constructor ({ port, channel, configuration }: {
     port: string;
-    channel: MidiChannel;
+    channel: Channel;
     configuration?: Configuration;
   }) {
     super({ port, channel });

--- a/lib/types/MidiChannel.ts
+++ b/lib/types/MidiChannel.ts
@@ -1,7 +1,0 @@
-type MidiChannel =
-  1 | 2 | 3 | 4 |
-  5 | 6 | 7 | 8 |
-  9 | 10 | 11 | 12 |
-  13 | 14 | 15 | 16;
-
-export { MidiChannel };


### PR DESCRIPTION
Turns out easymidi already defines a Channel Type, that goes from 0 to 15. Redefining this as number made Typescript think, the options object was a numbers array and this is send method excepting a  numbers Array is the one with the event 'sysex'

Using the type from easymidi solves the problem.